### PR TITLE
Support for PHP 7.4 in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "OSL-3.0"
   ],
   "require": {
-    "php": "~7.0.0|~7.1.0|~7.2.0|~7.3.0",
+    "php": "~7.0.0|~7.1.0|~7.2.0|~7.3.0|~7.4.0",
     "magento/product-community-edition": "^2.3",
     "tpay-com/tpay-php": "^2.2"
   },


### PR DESCRIPTION
Based on basic linting with PHP 7.4 looks like this code is not using anything that would prevent this from working with PHP 7.4 (now supported by Mangeto2)